### PR TITLE
fix typo on error handling

### DIFF
--- a/sftp.js
+++ b/sftp.js
@@ -124,7 +124,7 @@
 				node.status({
 				  shape: "dot",
 				  fill: "red",
-				  text : "Error: " + error 
+				  text : "Error: " + err
 				});
 				
 				msg.payload = err;


### PR DESCRIPTION
there is a typo in error handling code which causes crash:

```shell
(node:16) UnhandledPromiseRejectionWarning: ReferenceError: error is not defined
    at sftp.connect.then.then.catch (/home/node/app/node_modules/node-red-contrib-sftp/sftp.js:126:26)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:188:7)
(node:16) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:16) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```